### PR TITLE
input field alignment

### DIFF
--- a/popup/timer.js
+++ b/popup/timer.js
@@ -50,10 +50,10 @@ function stopTimer() {
 }
 
 function resetTimer() {
-    minute = 0;
-    second = 0;
-    document.getElementById('minute').innerText =  returnData(minute);
-    document.getElementById('second').innerText =  returnData(second);
+    minute =0;
+    second =0;
+    document.getElementById('minute').innerText = returnData(minute);
+    document.getElementById('second').innerText = returnData(second);
     clearInterval(timerInterval);
     toogleVisibility(inputTime, true);
 }
@@ -64,7 +64,7 @@ function returnData(data) {
 
 function toogleVisibility(element, resetTimer)  {
     if (element.style.display === "none" && resetTimer) {
-        element.style.display = "block";
+        element.style.display = "inline";
     } else if(!resetTimer){
         element.style.display = "none";
     }  


### PR DESCRIPTION
Upon reset, the input field was set to appear as a block element. Since the input field is originally set to display inline, we will display the input field inline after reset as well.